### PR TITLE
add docker-composer for php, database and composer services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,28 @@
+version: "3.8"
+
+services:
+    php:
+        build:
+            context: ./
+            dockerfile: ./docker/php-fpm/Dockerfile
+        environment:
+            DB_CONNECTION: testing
+            DB_HOST_TESTING: database
+            DB_DATABASE_TESTING: laravel_ddd_testing
+            DB_USERNAME_TESTING: laravelddd
+            DB_PASSWORD_TESTING: laravelddd
+        volumes:
+            - .:/var/www/html
+
+    database:
+        image: "mysql:8.0"
+        environment:
+            MYSQL_ROOT_PASSWORD: root
+            MYSQL_DATABASE: laravel_ddd_testing
+            MYSQL_USER: laravelddd
+            MYSQL_PASSWORD: laravelddd
+
+    composer:
+        image: "composer:2.6.5"
+        volumes:
+            - .:/app


### PR DESCRIPTION
### Context

Add `docker-composer` for `php`, `database` and `composer` services.